### PR TITLE
Fixed default tag return value when using classes like StaticAsset

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -107,6 +107,8 @@ class exports.Asset extends EventEmitter
                 return tag += "src=\"#{@specificUrl}\"></script>"
             when 'text/css'
                 return "<link rel=\"stylesheet\" href=\"#{@specificUrl}\">"
+            else
+                return @specificUrl
     createSpecificUrl: ->
         @md5 = crypto.createHash('md5').update(@contents).digest 'hex'
         unless @hash


### PR DESCRIPTION
This fixes issues when you want to return just the link to your assets like it is the case with StaticAsset class.
