### PR TITLE
Added support for snockets dependency js/coffee concatenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ new SnocketsAsset({
 * `url`: The url that should retrieve this resource.
 * `filename`: A filename or list of filenames to be executed by the browser.
 * `compress` (defaults to false): whether to run the javascript through a minifier.
+* `debug` (defaults to false): output scripts via eval with trailing //@ sourceURL
 * `hash` (defaults to true): Set to false if you don't want the md5 sum added to your urls.
 
 ## JadeAsset

--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ Inspired by Trevor Burnham's [connect-assets](https://github.com/TrevorBurnham/c
 
 1. Dynamic asset creation for js, css, html templates.
 2. Support for js/coffescript, browserify (node-style requires).
-3. Support for less.
-4. Support for jade templates.
-4. Multi-process, multi-server out of the box.  Share nothing.
-5. Filenames hashed for "forever" HTML caching and easy CDN updates.
-6. No need to ever compile static files to disk, all-in memory.
-7. Ability to push compiled files to Amazon S3 for use with Cloudfront.
-8. Can be plugged into express as connect middleware.
-9. Easily extensible.
+3. Support for snockets (Rails/Sprockets-style comments to indicate dependencies).
+4. Support for less.
+5. Support for jade templates.
+6. Multi-process, multi-server out of the box.  Share nothing.
+7. Filenames hashed for "forever" HTML caching and easy CDN updates.
+8. No need to ever compile static files to disk, all-in memory.
+9. Ability to push compiled files to Amazon S3 for use with Cloudfront.
+10. Can be plugged into express as connect middleware.
+11. Easily extensible.
 
 ## Install
 
@@ -188,6 +189,26 @@ new BrowserifyAsset({
 * `filename`: A filename or list of filenames to be executed by the browser.
 * `require`: A filename or list of filenames to require, should not be necessary
 as the `filename` argument should pull in any requires you need.
+* `compress` (defaults to false): whether to run the javascript through a minifier.
+* `hash` (defaults to true): Set to false if you don't want the md5 sum added to your urls.
+
+## Snockets (js/coffeescript)
+
+Snockets is a JavaScript/CoffeeScript concatenation tool for Node.js inspired by Sprockets. Used by connect-assets to create a Rails 3.1-style asset pipeline.  For more details, check it out,
+[here](https://github.com/TrevorBurnham/snockets).
+
+```javascript
+new SnocketsAsset({
+    url: '/app.js',
+    filename: __dirname + '/client/app.js',
+    compress: true
+});
+```
+
+### Options
+
+* `url`: The url that should retrieve this resource.
+* `filename`: A filename or list of filenames to be executed by the browser.
 * `compress` (defaults to false): whether to run the javascript through a minifier.
 * `hash` (defaults to true): Set to false if you don't want the md5 sum added to your urls.
 

--- a/lib/assets/snockets.coffee
+++ b/lib/assets/snockets.coffee
@@ -1,0 +1,12 @@
+Snockets = require 'snockets'
+Asset = require('../index').Asset
+
+class exports.SnocketsAsset extends Asset
+    mimetype: 'text/javascript'
+
+    create: ->
+        @filename = @options.filename
+        @compress = @options.compress or false
+        snockets = new Snockets()
+        @contents = snockets.getConcatenation @filename, { async: false, minify: @compress }
+        @emit 'complete'

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -123,4 +123,5 @@ exports.BrowserifyAsset = require('./assets/browserify').BrowserifyAsset
 exports.JadeAsset = require('./assets/jade').JadeAsset
 exports.StaticAssetRack = require('./assets/static').StaticAssetRack
 exports.StaticAsset = require('./assets/static').StaticAsset
+exports.SnocketsAsset = require('./assets/snockets').SnocketsAsset
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "coffee-script": "1.3.1",
         "browserify": "1.13.5",
+        "snockets": "1.3.8",
         "uglify-js": "1.3.0",
         "async": "0.1.22",
         "knox": "0.0.9",


### PR DESCRIPTION
https://github.com/TrevorBurnham/snockets

Browserify does not always work well with 3rd party javascript libs, snockets is based on Rails 3.1-style asset pipeline.
