### PR TITLE
Updated browserify, uglify and less dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
     "repository": "git://github.com/techpines/asset-rack",
     "dependencies": {
         "coffee-script": "1.3.1",
-        "browserify": "1.13.5",
-        "uglify-js": "1.3.0",
+        "browserify": "1.16.1",
+        "uglify-js": "1.3.4",
         "async": "0.1.22",
         "knox": "0.0.9",
-        "less": "1.3.0",
+        "less": "1.3.1",
         "jade": "0.27.0",
         "mime": "1.2.6"
     },


### PR DESCRIPTION
Fixes a node 0.8.x warning that was fixed with later versions of browserify
