### PR TITLE
Pass through a debug option to browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ new BrowserifyAsset({
 * `filename`: A filename or list of filenames to be executed by the browser.
 * `require`: A filename or list of filenames to require, should not be necessary
 as the `filename` argument should pull in any requires you need.
+* `debug` (defaults to false): enables the browserify debug option.
 * `compress` (defaults to false): whether to run the javascript through a minifier.
 * `hash` (defaults to true): Set to false if you don't want the md5 sum added to your urls.
 

--- a/lib/assets/browserify.coffee
+++ b/lib/assets/browserify.coffee
@@ -12,8 +12,9 @@ class exports.BrowserifyAsset extends Asset
     create: ->
         @filename = @options.filename
         @require = @options.require
+        @debug = @options.debug or false
         @compress = @options.compress or false
-        agent = browserify watch: false
+        agent = browserify watch: false, debug: @debug
         agent.addEntry @filename
         agent.require @require if @require
         if @options.compress is true


### PR DESCRIPTION
Enables browserify to output the //@ sourceURL=... notation for better debug file and line numbering info
