### PR TITLE
Enable custom extension handlers to be passed through to browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ new BrowserifyAsset({
 * `require`: A filename or list of filenames to require, should not be necessary
 as the `filename` argument should pull in any requires you need.
 * `compress` (defaults to false): whether to run the javascript through a minifier.
+* `extensionHandlers` (defaults to []): an array of custom extensions and associated handler function. eg: `[{ ext: 'handlebars', handler: handlebarsCompilerFunction }]`
 * `hash` (defaults to true): Set to false if you don't want the md5 sum added to your urls.
 
 ## JadeAsset

--- a/lib/assets/browserify.coffee
+++ b/lib/assets/browserify.coffee
@@ -13,7 +13,10 @@ class exports.BrowserifyAsset extends Asset
         @filename = @options.filename
         @require = @options.require
         @compress = @options.compress or false
+        @extensionHandlers = @options.extensionHandlers or []
         agent = browserify watch: false
+        for handler in @extensionHandlers
+          agent.register(handler.ext, handler.handler)
         agent.addEntry @filename
         agent.require @require if @require
         if @options.compress is true


### PR DESCRIPTION
Example usage: 

``` javascript
  new rack.BrowserifyAsset({
    url: '/js/app.js',
    filename: __dirname + '/assets/js/app.js',
    extensionHandlers: [{ ext: 'handlebars', handler: handlebarsCompiler }]
  })
```

Where each `ext` and `handler` will be passed to the `browserify.register()` method as defined here https://github.com/substack/node-browserify/blob/master/doc/methods.markdown#bregisterext-fn
