### PR TITLE
Checking if there are url() properties before amending them.

### DIFF
--- a/lib/modules/less.coffee
+++ b/lib/modules/less.coffee
@@ -24,12 +24,13 @@ class exports.LessAsset extends Asset
                 if @rack?
                     urlRegex = "url\s*\(\s*'([^']+)'\s*\)"
                     results = raw.match /url\s*\(\s*'([^']+)'\s*\)/g
-                    for result in results
-                        match = /url\s*\(\s*'([^']+)'\s*\)/.exec result
-                        url = match[1]
-                        specificUrl = @rack.url url
-                        if specificUrl?
-                            raw = raw.replace result, "url('#{specificUrl}')"
+                    if results
+                        for result in results
+                            match = /url\s*\(\s*'([^']+)'\s*\)/.exec result
+                            url = match[1]
+                            specificUrl = @rack.url url
+                            if specificUrl?
+                                raw = raw.replace result, "url('#{specificUrl}')"
                 @emit 'created', contents: raw
         catch error
             @emit 'error', error

--- a/test/less.coffee
+++ b/test/less.coffee
@@ -53,6 +53,9 @@ describe 'a less asset', ->
                 url: '/background.png'
                 contents: 'not a real png'
             new rack.LessAsset
+                filename: "#{__dirname}/fixtures/less/simple.less"
+                url: '/simple.css'
+            new rack.LessAsset
                 filename: "#{__dirname}/fixtures/less/dependency.less"
                 url: '/style.css'
         ]


### PR DESCRIPTION
Errors are thrown if you add a LESS asset, in to a rack, that doesn't have any url() properties.
