### PR TITLE
Getting stuff to work in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.exrc
+_exrc
 node_modules
+*.log
 *.swo
 *.swp

--- a/lib/modules/static.coffee
+++ b/lib/modules/static.coffee
@@ -11,6 +11,7 @@ class exports.StaticAssets extends Asset
     create: (options) ->
         @dirname = pathutil.resolve options.dirname
         @urlPrefix = options.urlPrefix
+        @urlPrefix += '/' unless @urlPrefix.substr(-1, 1) is '/'
         @assets = []
         @getAssets @dirname, @urlPrefix, =>
             @emit 'created'
@@ -27,8 +28,7 @@ class exports.StaticAssets extends Asset
                     @assets.concat newAssets
                     next()
             else
-                basePath = pathutil.dirname @dirname
-                url = path.replace basePath, ''
+                url = prefix + filename
                 ext = pathutil.extname path
                 mimetype = mime.types[ext.slice(1, ext.length)]
                 contents = fs.readFileSync path

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "chai": "1.4.2"
     },
     "scripts": {
-        "test": "cd test; ./test.sh"
+        "test": "mocha --compilers coffee:coffee-script test/test.coffee --reporter spec --timeout 5000 --ignore-leaks"
     },
     "main": "switch.js",
     "engines": { "node":">= 0.5.0" }

--- a/test/browserify.coffee
+++ b/test/browserify.coffee
@@ -7,12 +7,13 @@ fs = require 'fs'
 
 describe 'a browserify asset', ->
     app = null
+    fixturesDir = "#{__dirname}/fixtures/browserify"
 
     it 'should work', (done) ->
-        compiled = fs.readFileSync './fixtures/browserify/app.js', 'utf8'
+        compiled = fs.readFileSync "#{fixturesDir}/app.js", 'utf8'
         app = express().http()
         app.use new rack.BrowserifyAsset
-            filename: "#{__dirname}/fixtures/browserify/app.coffee"
+            filename: "#{fixturesDir}/app.coffee"
             url: '/app.js'
         app.listen 7076, ->
             easyrequest 'http://localhost:7076/app.js', (error, response, body) ->
@@ -21,10 +22,10 @@ describe 'a browserify asset', ->
                 done()
 
     it 'should work compressed', (done) ->
-        compiled = fs.readFileSync './fixtures/browserify/app.min.js', 'utf8'
+        compiled = fs.readFileSync "#{fixturesDir}/app.min.js", 'utf8'
         app = express().http()
         app.use asset = new rack.BrowserifyAsset
-            filename: "#{__dirname}/fixtures/browserify/app.coffee"
+            filename: "#{fixturesDir}/app.coffee"
             url: '/app.js'
             compress: true
         app.listen 7076, ->

--- a/test/jade.coffee
+++ b/test/jade.coffee
@@ -7,12 +7,13 @@ fs = require 'fs'
 
 describe 'a jade asset', ->
     app = null
+    fixturesDir = "#{__dirname}/fixtures/jade"
 
     it 'should work', (done) ->
-        compiled = fs.readFileSync './fixtures/jade/templates.js', 'utf8'
+        compiled = fs.readFileSync "#{fixturesDir}/templates.js", 'utf8'
         app = express().http()
         app.use new rack.JadeAsset
-            dirname: "#{__dirname}/fixtures/jade"
+            dirname: fixturesDir
             url: '/templates.js'
         app.listen 7076, ->
             easyrequest 'http://localhost:7076/templates.js', (error, response, body) ->
@@ -20,21 +21,21 @@ describe 'a jade asset', ->
                 body.should.equal compiled
                 window = {}
                 eval(body)
-                testFile = fs.readFileSync "#{__dirname}/fixtures/jade/test.html", 'utf8'
+                testFile = fs.readFileSync "#{fixturesDir}/test.html", 'utf8'
                 window.Templates.test().should.equal testFile
-                userFile = fs.readFileSync "#{__dirname}/fixtures/jade/user.html", 'utf8'
+                userFile = fs.readFileSync "#{fixturesDir}/user.html", 'utf8'
                 window.Templates.user(users: ['fred', 'steve']).should.equal userFile
                 done()
 
     it 'should work in a rack', (done) ->
-        compiled = fs.readFileSync './fixtures/jade/templates-rack.js', 'utf8'
+        compiled = fs.readFileSync "#{fixturesDir}/templates-rack.js", 'utf8'
         app = express().http()
         app.use new rack.AssetRack [
             new rack.Asset
                 url: '/image.png'
-                contents: fs.readFileSync './fixtures/jade/image.png', 'utf8'
+                contents: fs.readFileSync "#{fixturesDir}/image.png", 'utf8'
             new rack.JadeAsset
-                dirname: "#{__dirname}/fixtures/jade"
+                dirname: fixturesDir
                 url: '/templates-rack.js'
         ]
         app.listen 7076, ->
@@ -43,19 +44,19 @@ describe 'a jade asset', ->
                 body.should.equal compiled
                 window = {}
                 eval(body)
-                testFile = fs.readFileSync "#{__dirname}/fixtures/jade/test.html", 'utf8'
+                testFile = fs.readFileSync "#{fixturesDir}/test.html", 'utf8'
                 window.Templates.test().should.equal testFile
-                userFile = fs.readFileSync "#{__dirname}/fixtures/jade/user.html", 'utf8'
+                userFile = fs.readFileSync "#{fixturesDir}/user.html", 'utf8'
                 window.Templates.user(users: ['fred', 'steve']).should.equal userFile
-                dependencyFile = fs.readFileSync "#{__dirname}/fixtures/jade/dependency.html", 'utf8'
+                dependencyFile = fs.readFileSync "#{fixturesDir}/dependency.html", 'utf8'
                 window.Templates.dependency().should.equal dependencyFile
                 done()
 
     it 'should work compressed', (done) ->
-        compiled = fs.readFileSync './fixtures/jade/templates.min.js', 'utf8'
+        compiled = fs.readFileSync "#{fixturesDir}/templates.min.js", 'utf8'
         app = express().http()
         app.use new rack.JadeAsset
-            dirname: "#{__dirname}/fixtures/jade"
+            dirname: "#{fixturesDir}"
             url: '/templates.min.js'
             compress: true
         app.listen 7076, ->
@@ -64,9 +65,9 @@ describe 'a jade asset', ->
                 body.should.equal compiled
                 window = {}
                 eval(body)
-                testFile = fs.readFileSync "#{__dirname}/fixtures/jade/test.html", 'utf8'
+                testFile = fs.readFileSync "#{fixturesDir}/test.html", 'utf8'
                 window.Templates.test().should.equal testFile
-                userFile = fs.readFileSync "#{__dirname}/fixtures/jade/user.html", 'utf8'
+                userFile = fs.readFileSync "#{fixturesDir}/user.html", 'utf8'
                 window.Templates.user(users: ['fred', 'steve']).should.equal userFile
                 done()
 

--- a/test/less.coffee
+++ b/test/less.coffee
@@ -9,7 +9,7 @@ describe 'a less asset', ->
     app = null
 
     it 'should work', (done) ->
-        compiled = fs.readFileSync './fixtures/less/simple.css', 'utf8'
+        compiled = fs.readFileSync "#{__dirname}/fixtures/less/simple.css", 'utf8'
         app = express().http()
         app.use new rack.LessAsset
             filename: "#{__dirname}/fixtures/less/simple.less"
@@ -21,7 +21,7 @@ describe 'a less asset', ->
                 done()
 
     it 'should work compressed', (done) ->
-        compiled = fs.readFileSync './fixtures/less/simple.min.css', 'utf8'
+        compiled = fs.readFileSync "#{__dirname}/fixtures/less/simple.min.css", 'utf8'
         app = express().http()
         app.use new rack.LessAsset
             filename: "#{__dirname}/fixtures/less/simple.less"

--- a/test/snockets.coffee
+++ b/test/snockets.coffee
@@ -7,12 +7,13 @@ fs = require 'fs'
 
 describe 'a snockets asset', ->
     app = null
+    fixturesDir = "#{__dirname}/fixtures/snockets"
 
     it 'should work', (done) ->
-        compiled = fs.readFileSync './fixtures/snockets/app.js', 'utf8'
+        compiled = fs.readFileSync "#{fixturesDir}/app.js", 'utf8'
         app = express().http()
         app.use new rack.SnocketsAsset
-            filename: "#{__dirname}/fixtures/snockets/app.coffee"
+            filename: "#{fixturesDir}/app.coffee"
             url: '/app.js'
         app.listen 7076, ->
             easyrequest 'http://localhost:7076/app.js', (error, response, body) ->
@@ -21,10 +22,10 @@ describe 'a snockets asset', ->
                 done()
 
     it 'should work compressed', (done) ->
-        compiled = fs.readFileSync './fixtures/snockets/app.min.js', 'utf8'
+        compiled = fs.readFileSync "#{fixturesDir}/app.min.js", 'utf8'
         app = express().http()
         app.use new rack.SnocketsAsset
-            filename: "#{__dirname}/fixtures/snockets/app.coffee"
+            filename: "#{fixturesDir}/app.coffee"
             url: '/app.js'
             compress: true
         app.listen 7076, ->

--- a/test/static.coffee
+++ b/test/static.coffee
@@ -9,10 +9,11 @@ describe 'a static asset builder', ->
     app = null
     
     it 'should work', (done) ->
-        compiled = fs.readFileSync "#{__dirname}/fixtures/static/blank.txt", 'utf8'
+        staticPath = "#{__dirname}/fixtures/static"
+        compiled = fs.readFileSync "#{staticPath}/blank.txt", 'utf8'
         app = express().http()
         app.use new rack.StaticAssets
-            dirname: "./fixtures/static"
+            dirname: staticPath
             urlPrefix: '/static'
         app.listen 7076, ->
             easyrequest 'http://localhost:7076/static/blank.txt', (error, response, body) ->

--- a/test/stylus.coffee
+++ b/test/stylus.coffee
@@ -7,12 +7,13 @@ fs = require 'fs'
 
 describe 'a stylus asset', ->
     app = null
+    fixturesDir = "#{__dirname}/fixtures/stylus"
 
     it 'should work', (done) ->
-        compiled = fs.readFileSync './fixtures/stylus/simple.css', 'utf8'
+        compiled = fs.readFileSync "#{fixturesDir}/simple.css", 'utf8'
         app = express().http()
         app.use new rack.StylusAsset
-            filename: "#{__dirname}/fixtures/stylus/simple.styl"
+            filename: "#{fixturesDir}/simple.styl"
             url: '/style.css'
         app.listen 7076, ->
             easyrequest 'http://localhost:7076/style.css', (error, response, body) ->
@@ -21,10 +22,10 @@ describe 'a stylus asset', ->
                 done()
 
     it 'should work compressed', (done) ->
-        compiled = fs.readFileSync './fixtures/stylus/simple.min.css', 'utf8'
+        compiled = fs.readFileSync "#{fixturesDir}/simple.min.css", 'utf8'
         app = express().http()
         app.use new rack.StylusAsset
-            filename: "#{__dirname}/fixtures/stylus/simple.styl"
+            filename: "#{fixturesDir}/simple.styl"
             url: '/style.css'
             compress: true
         app.listen 7076, ->


### PR DESCRIPTION
Unfortunately, at my place of work, we're all on Windows and during my investigation of asset-rack I've hit a lot of hurdles getting it to work :(

My first issue was that the static assets class uses the 'path' module to create URLs which will turn a URL from '/static/blank.txt' in to '\static\blank.txt'.

Then, when I checked out the project on to my windows machine, to make a patch, I couldn't get the tests running. I don't know if you'll like my solution, but I have changed the command in the package.json to the actual mocha command rather than running it through a shell script. But of course, this means that the resolving path wasn't correct when loading fixtures. So that has been changed too.
