### PR TITLE
fix for StaticAssets when a file has an unrecognized mime type

### DIFF
--- a/lib/modules/static.coffee
+++ b/lib/modules/static.coffee
@@ -42,6 +42,8 @@ class exports.StaticAssets extends Asset
                     asset.on 'complete', =>
                         @assets.push asset
                         next()
+                else
+                    next()
         , (error) ->
             next()
         


### PR DESCRIPTION
If a file in a StaticAssets directory has an invalid mime type, it will short-circuit the forEachSeries: next() will not be called. So the rest of the files won't be added to the static assets. 

Eg. for this directory structure:
/static
   test.css
   zzz.file

zzz.file will never get next() called, and the next files won't get added to the static assets.
