### PR TITLE
url replacement broken when referencing static assets (images) from inside stylus and less assets

### DIFF
--- a/lib/modules/less.coffee
+++ b/lib/modules/less.coffee
@@ -3,6 +3,8 @@ less = require 'less'
 fs = require 'fs'
 pathutil = require 'path'
 Asset = require('../.').Asset
+urlRegex = /url\s*\(\s*(['"])((?:(?!\1).)+)\1\s*\)/
+urlRegexGlobal = /url\s*\(\s*(['"])((?:(?!\1).)+)\1\s*\)/g
 
 class exports.LessAsset extends Asset
     create: (options) ->
@@ -22,15 +24,15 @@ class exports.LessAsset extends Asset
                 return @emit 'error', error if error?
                 raw = tree.toCSS compress: @compress
                 if @rack?
-                    urlRegex = "url\s*\(\s*'([^']+)'\s*\)"
-                    results = raw.match /url\s*\(\s*'([^']+)'\s*\)/g
+                    results = raw.match urlRegexGlobal
                     if results
                         for result in results
-                            match = /url\s*\(\s*'([^']+)'\s*\)/.exec result
-                            url = match[1]
+                            match = urlRegex.exec result
+                            quote = match[1]
+                            url = match[2]
                             specificUrl = @rack.url url
                             if specificUrl?
-                                raw = raw.replace result, "url('#{specificUrl}')"
+                                raw = raw.replace result, "url(#{quote}#{specificUrl}#{quote})"
                 @emit 'created', contents: raw
         catch error
             @emit 'error', error

--- a/lib/modules/stylus.coffee
+++ b/lib/modules/stylus.coffee
@@ -4,6 +4,8 @@ pathutil = require 'path'
 nib = require 'nib'
 stylus = require 'stylus'
 Asset = require('../.').Asset
+urlRegex = /url\s*\(\s*(['"])((?:(?!\1).)+)\1\s*\)/
+urlRegexGlobal = /url\s*\(\s*(['"])((?:(?!\1).)+)\1\s*\)/g
 
 class exports.StylusAsset extends Asset
     create: (options) ->
@@ -21,13 +23,13 @@ class exports.StylusAsset extends Asset
                 .render (error, css) =>
                     return @emit 'error', error if error?
                     if @rack?
-                        urlRegex = "url\s*\(\s*'([^']+)'\s*\)"
-                        results = css.match /url\s*\(\s*'([^']+)'\s*\)/g
+                        results = css.match urlRegexGlobal
                         if results
                             for result in results
-                                match = /url\s*\(\s*'([^']+)'\s*\)/.exec result
-                                url = match[1]
+                                match = urlRegex.exec result
+                                quote = match[1]
+                                url = match[2]
                                 specificUrl = @rack.url url
                                 if specificUrl?
-                                    css = css.replace result, "url('#{specificUrl}')"
+                                    css = css.replace result, "url(#{quote}#{specificUrl}#{quote})"
                     @emit 'created', contents: css


### PR DESCRIPTION
The regular expressions being used look for single quotes around the filename within the url() css function, and stylus (at least on my machines) produces output wrapped in double quotes. Also, recreating these regular expression instances every time the Asset::create method runs is inefficient.

This patch works with either quote style, preserving whatever style was used, and moves the regexp creation to the top of the file where it only has to happen once.

CSS also allows the syntax url(/some/filename.ext), without quotes, which neither the original regexp, nor this patch, addresses. Whether that's legal syntax for less and/or stylus, I don't know.
