### PR TITLE
stylus asset takes an additional option for manual configuration

### DIFF
--- a/lib/modules/stylus.coffee
+++ b/lib/modules/stylus.coffee
@@ -12,18 +12,20 @@ class exports.StylusAsset extends Asset
         @filename = pathutil.resolve options.filename
         @compress = options.compress
         @compress ?= false
+        @config = options.config
+        @config ?= ->
+          @use nib()
 
         fs.readFile @filename, 'utf8', (error, data) =>
             return @emit 'error', error if error?
             styl = stylus(data)
+                .set('compress', @compress)
+                .set('include css', true)
 
-            options.config?.call styl, styl
+            @config.call styl, styl
 
             styl
                 .set('filename', @filename)
-                .set('compress', @compress)
-                .set('include css', true)
-                .use(nib())
                 .render (error, css) =>
                     return @emit 'error', error if error?
                     if @rack?

--- a/lib/modules/stylus.coffee
+++ b/lib/modules/stylus.coffee
@@ -11,7 +11,7 @@ class exports.StylusAsset extends Asset
     create: (options) ->
         @filename = pathutil.resolve options.filename
         @compress = options.compress
-        @compress ?= false
+        @compress ?= process.env.NODE_ENV == 'production'
         @config = options.config
         @config ?= ->
           @use nib()

--- a/lib/modules/stylus.coffee
+++ b/lib/modules/stylus.coffee
@@ -15,7 +15,11 @@ class exports.StylusAsset extends Asset
 
         fs.readFile @filename, 'utf8', (error, data) =>
             return @emit 'error', error if error?
-            stylus(data)
+            styl = stylus(data)
+
+            options.config?.call styl, styl
+
+            styl
                 .set('filename', @filename)
                 .set('compress', @compress)
                 .set('include css', true)


### PR DESCRIPTION
I needed a way to use [bootstrap-stylus](https://github.com/shomeya/bootstrap-stylus) with the stylus asset so I made a small modification to allow manually configuring the stylus compiler via an additional option.

I opted to use `options.config?.call styl styl` so that it would look good in both coffeescript and javascript.

eg: coffeescript

``` coffeescript
new StylusAsset
  url: '/style.css'
  filename: __dirname + '/style/fun.styl'
  config: ->
    @use bootstrap()
    @define 'setting', 90
```

eg: javascript

``` javascript
new StylusAsset({
  url: '/style.css',
  filename: __dirname + '/style/fun.styl',
  config: function (stylus) {
    stylus // using "this" here seems a little unnatural
      .use(bootstrap())
      .define('setting', 90);
  }
});
```
