### PR TITLE
utils.walk method added; DynamicAssets class added; StaticAssets re-implemented to use DynamicAssets

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -4,6 +4,7 @@ exports.ClientRack = require('./client').ClientRack
 exports.Rack = require('./rack').Rack
 exports.fromConfigFile = require('./rack').fromConfigFile
 exports.AssetRack = require('./rack').Rack # backwards compatibility with 1.x
+exports.DynamicAssets = require('./modules/dynamic').DynamicAssets
 exports.LessAsset = require('./modules/less').LessAsset
 exports.StylusAsset = require('./modules/stylus').StylusAsset
 exports.BrowserifyAsset = require('./modules/browserify').BrowserifyAsset
@@ -12,3 +13,6 @@ exports.StaticAssets = require('./modules/static').StaticAssets
 exports.SnocketsAsset = require('./modules/snockets').SnocketsAsset
 exports.AngularTemplatesAsset = require('./modules/angular-templates').AngularTemplatesAsset
 
+util = require './util'
+exports.utils =
+  walk: util.walk

--- a/lib/modules/dynamic.coffee
+++ b/lib/modules/dynamic.coffee
@@ -1,0 +1,32 @@
+
+fs = require 'fs'
+pathutil = require 'path'
+async = require 'async'
+{Asset} = require '../.'
+{walk} = require '../util'
+
+class exports.DynamicAssets extends Asset
+    create: (options) ->
+        @dirname = pathutil.resolve options.dirname
+        {@type, @urlPrefix, @options, @filter} = options
+        @urlPrefix += '/' unless @urlPrefix.slice(-1) is '/'
+        @options ?= {}
+        @options.hash = @hash
+        @options.maxAge = @maxAge
+
+        @assets = []
+        walk @dirname,
+          ignoreFolders: true
+          filter: @filter
+          , (file, done) =>
+            opts =
+                url: @urlPrefix + file.relpath
+                filename: file.path
+            opts[k] = v for own k, v of @options
+            asset = new @type opts
+            asset.on 'complete', =>
+                @assets.push asset
+                done()
+          , (err) =>
+            return @emit 'error', err if err?
+            @emit 'created'

--- a/lib/modules/static.coffee
+++ b/lib/modules/static.coffee
@@ -2,48 +2,20 @@
 fs = require 'fs'
 pathutil = require 'path'
 async = require 'async'
-rack = require '../index'
 mime = require 'mime'
-EventEmitter = require('events').EventEmitter
-Asset = require('../.').Asset
+{Asset} = require '../.'
+{DynamicAssets} = require './dynamic'
 
-class exports.StaticAssets extends Asset
+class StaticAsset extends Asset
     create: (options) ->
-        @dirname = pathutil.resolve options.dirname
-        @urlPrefix = options.urlPrefix
-        @urlPrefix += '/' unless @urlPrefix.substr(-1, 1) is '/'
-        @assets = []
-        @getAssets @dirname, @urlPrefix, =>
-            @emit 'created'
-    
-    getAssets: (dirname, prefix='', next) ->
-        filenames = fs.readdirSync dirname
-        async.forEachSeries filenames, (filename, next) =>
-            return next() if filename.slice(0, 1) is '.'
-            path = pathutil.join dirname, filename
-            stats = fs.statSync path
-            if stats.isDirectory()
-                newPrefix = "#{prefix}#{pathutil.basename(path)}/"
-                @getAssets path, newPrefix, (newAssets) =>
-                    @assets.concat newAssets
-                    next()
-            else
-                url = prefix + filename
-                ext = pathutil.extname path
-                mimetype = mime.types[ext.slice(1, ext.length)]
-                contents = fs.readFileSync path
-                if mimetype?
-                    asset = new Asset
-                        url: url
-                        contents: contents
-                        mimetype: mime.types[ext.slice(1, ext.length)]
-                        hash: @hash
-                        maxAge: @maxAge
-                    asset.on 'complete', =>
-                        @assets.push asset
-                        next()
-                else
-                    next()
-        , (error) ->
-            next()
-        
+        @filename = pathutil.resolve options.filename
+        @mimetype ?= mime.types[pathutil.extname(@filename).slice 1] || 'text/plain'
+
+        fs.readFile @filename, 'utf8', (error, data) =>
+            return @emit 'error', error if error?
+            @emit 'created', contents: data
+
+class exports.StaticAssets extends DynamicAssets
+    constructor: (options) ->
+        options?.type = StaticAsset
+        super options

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -2,6 +2,9 @@
 EventEmitter = require('events').EventEmitter
 Buffer = require('buffer').Buffer
 _ = require 'underscore'
+fs = require 'fs'
+pathutil = require 'path'
+async = require 'async'
 
 class exports.BufferStream extends EventEmitter
     constructor: (buffer) ->
@@ -23,3 +26,42 @@ exports.extend = (object) ->
     for key, value of object
         Asset::[key] = value
     Asset
+
+exports.walk = (root, options, iterator, cb) ->
+  if _.isFunction options
+    cb = iterator
+    iterator = options
+    options = {}
+  cb ?= ->
+  ignoreFolders = options.ignoreFolders || false
+  filter = options.filter || -> true
+
+  if _.isString filter
+    filter = ((ext) ->
+      ext = if ext[0] is '.' then ext else '.' + ext
+      (file) -> file.ext == ext
+    ) filter
+
+  readdir = (dir, cb) ->
+    fs.readdir dir, (err, files) ->
+      return cb err if err?
+      iter = (file, done) ->
+        path = pathutil.join dir, file
+        fs.stat path, (err, stats) ->
+          return done err if err?
+          fobj =
+            name: pathutil.basename file
+            relpath: pathutil.relative root, path
+            path: path
+            ext: pathutil.extname file
+            stats: stats
+          skip = (ignoreFolders and stats.isDirectory()) or !filter fobj
+          if stats.isDirectory()
+            readdir path, (err) ->
+              return done err if err?
+              if skip then done() else iterator fobj, done
+          else
+            if skip then done() else iterator fobj, done
+      async.forEach files, iter, cb
+
+  readdir root, cb


### PR DESCRIPTION
https://github.com/techpines/asset-rack/issues/38

Woo! That was fun :D
Just hope I didn't break anything...
(All the existing tests are passing though.)

So I've added a walk function

``` coffee
rack.utils.walk dirname, [options,] iterator [, callback]
```

As you can see I drew from the async api; and it works asynchronously.
Should I make a synchronous version as well?

> Note: in the end I didn't use `wrench-js` due to a few problems making the entire walk function asynchronous

eg:

``` coffee
walk '/somedir',
  ignoreFolders: true # folders won't be passed to the iterator
  filter: 'coffee' # only pass *.coffee files to the iterator; can also be a function
  , (file, done) -> # called for each file; done must be called
  , (err) -> # called after the last file (optional)
```

I've also added DynamicAssets which uses `walk` and StaticAssets now extends DynamicAssets.

``` coffee
new DynamicAssets
  type: StylusAsset
  filter: '.styl'
  dirname: '/styl'
  url: '/css'
  options:
    compress: true
    config: ->
      use nib()
```

---

Also I have a few details I need to clarify.
- While converting StaticAssets I made a class which is basically a single file version of StaticAssets

```
new StaticAsset
  url: '/hello-world.txt'
  filename: '/path/to/hello-world/file.txt'
```

Should I expose this? It might be useful to some users maybe?
- Should I make StaticAssets style classes for each of the builtin assets? ie. StylusAssets, LessAssets, etc.
- Which of the following styles should I use for passing arbitrary options the asset factory?

``` coffee
new DynamicAssets
  ...
  options: # via an options object...
    compress: true
```

``` coffee
new DynamicAssets
  ...
  compress: true # ...or directly to the constructor?
```

---

I'll be make some tests for the new additions a little later.

PS: Sorry for the wall of text :)
