### PR TITLE
rewriteExt option added to DynamicAssets; potential bug with windows paths fixed

### DIFF
--- a/lib/modules/angular-templates.coffee
+++ b/lib/modules/angular-templates.coffee
@@ -4,6 +4,8 @@ uglify = require 'uglify-js'
 Asset = require('../index').Asset
 
 class exports.AngularTemplatesAsset extends Asset
+    @mimetype: 'application/javascript'
+
     create: (options) ->
         options.dirname ?= options.directory # for backwards compatiblity
         @dirname = pathutil.resolve options.dirname

--- a/lib/modules/browserify.coffee
+++ b/lib/modules/browserify.coffee
@@ -1,4 +1,3 @@
-
 fs = require 'fs'
 pathutil = require 'path'
 browserify = require 'browserify'
@@ -6,7 +5,8 @@ uglify = require('uglify-js')
 Asset = require('../index').Asset
 
 class exports.BrowserifyAsset extends Asset
-    mimetype: 'text/javascript'
+    @mimetype: 'application/javascript'
+
     create: (options) ->
         @filename = options.filename
         @require = options.require

--- a/lib/modules/dynamic.coffee
+++ b/lib/modules/dynamic.coffee
@@ -2,6 +2,7 @@
 fs = require 'fs'
 pathutil = require 'path'
 async = require 'async'
+mime = require 'mime'
 {Asset} = require '../.'
 {walk} = require '../util'
 
@@ -10,6 +11,7 @@ class exports.DynamicAssets extends Asset
         @dirname = pathutil.resolve options.dirname
         {@type, @urlPrefix, @options, @filter, @rewriteExt} = options
         @urlPrefix += '/' unless @urlPrefix.slice(-1) is '/'
+        @rewriteExt ?= mime.extensions[@type.mimetype] if @type.mimetype?
         @rewriteExt = '.' + @rewriteExt if @rewriteExt? and @rewriteExt[0] isnt '.'
         @options ?= {}
         @options.hash = @hash

--- a/lib/modules/jade.coffee
+++ b/lib/modules/jade.coffee
@@ -1,4 +1,3 @@
-
 fs = require 'fs'
 pathutil = require 'path'
 uglify = require 'uglify-js'
@@ -7,7 +6,8 @@ jade = require 'jade'
 Asset = require('../index').Asset
 
 class exports.JadeAsset extends Asset
-    mimetype: 'text/javascript'
+    @mimetype: 'application/javascript'
+
     create: (options) ->
         @dirname = pathutil.resolve options.dirname
         @separator = options.separator or '/'

--- a/lib/modules/less.coffee
+++ b/lib/modules/less.coffee
@@ -1,4 +1,3 @@
-
 less = require 'less'
 fs = require 'fs'
 pathutil = require 'path'
@@ -7,6 +6,8 @@ urlRegex = /url\s*\(\s*(['"])((?:(?!\1).)+)\1\s*\)/
 urlRegexGlobal = /url\s*\(\s*(['"])((?:(?!\1).)+)\1\s*\)/g
 
 class exports.LessAsset extends Asset
+    @mimetype: 'text/css'
+
     create: (options) ->
         @filename = pathutil.resolve options.filename
         @paths = options.paths

--- a/lib/modules/snockets.coffee
+++ b/lib/modules/snockets.coffee
@@ -3,7 +3,7 @@ Snockets = require 'snockets'
 Asset = require('../index').Asset
 
 class exports.SnocketsAsset extends Asset
-    mimetype: 'text/javascript'
+    @mimetype: 'application/javascript'
 
     create: (options) ->
         @filename = pathutil.resolve options.filename

--- a/lib/modules/stylus.coffee
+++ b/lib/modules/stylus.coffee
@@ -1,4 +1,3 @@
-
 fs = require 'fs'
 pathutil = require 'path'
 nib = require 'nib'
@@ -8,6 +7,8 @@ urlRegex = /url\s*\(\s*(['"])((?:(?!\1).)+)\1\s*\)/
 urlRegexGlobal = /url\s*\(\s*(['"])((?:(?!\1).)+)\1\s*\)/g
 
 class exports.StylusAsset extends Asset
+    @mimetype: 'text/css'
+
     create: (options) ->
         @filename = pathutil.resolve options.filename
         @compress = options.compress

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -51,6 +51,7 @@ exports.walk = (root, options, iterator, cb) ->
           return done err if err?
           fobj =
             name: pathutil.basename file
+            namenoext: pathutil.basename file, pathutil.extname file
             relpath: pathutil.relative root, path
             path: path
             ext: pathutil.extname file


### PR DESCRIPTION
I can't believe I didn't notice this earlier. There is a pretty big issue with `DynamicAssets`.
eg:

``` coffee
new DynamicAssets
  type: StylusAsset
  urlPrefix: '/css'
  dirname: '/styl'
```

This serves all the compiled stylus files with the `.styl` extension **not** the `.css` extension.
`/css/filename.styl` when it should be `/css/filename.css`
So I added the rewriteExt option; probably not be the best solution but thats all I could think of.

``` coffee
new DynamicAssets
  type: StylusAsset
  urlPrefix: '/css'
  dirname: '/styl'
  rewriteExt: 'css' # <- addition
```

---

I also fixed a potential problem with building the url directly with the `file.relpath` on windows.
