### PR TITLE
bugfix: stop StaticAsset from loading files using the utf8 encoding

### DIFF
--- a/lib/modules/static.coffee
+++ b/lib/modules/static.coffee
@@ -11,7 +11,7 @@ class StaticAsset extends Asset
         @filename = pathutil.resolve options.filename
         @mimetype ?= mime.types[pathutil.extname(@filename).slice 1] || 'text/plain'
 
-        fs.readFile @filename, 'utf8', (error, data) =>
+        fs.readFile @filename, (error, data) =>
             return @emit 'error', error if error?
             @emit 'created', contents: data
 


### PR DESCRIPTION
I made a pretty big mistake when re-implementing `StaticAssets`. Sorry.
