### PR TITLE
Adding error reporting to snocketAssets

### DIFF
--- a/lib/asset.coffee
+++ b/lib/asset.coffee
@@ -46,7 +46,7 @@ class exports.Asset extends EventEmitter
             @completed = true
             @emit 'complete'
         @on 'error', (error) =>
-            throw error if @listeners 'error' is 1
+            throw error if @listeners('error') is 1
         @on 'start', =>
             @maxAge ?= @rack?.maxAge
             @maxAge ?= @defaultMaxAge unless @hash is false

--- a/lib/modules/snockets.coffee
+++ b/lib/modules/snockets.coffee
@@ -6,23 +6,26 @@ class exports.SnocketsAsset extends Asset
     mimetype: 'text/javascript'
 
     create: (options) ->
-        @filename = pathutil.resolve options.filename
-        @compress = options.compress or false
-        @debug = options.debug or false
-        snockets = new Snockets()
-        if @debug
-            files = snockets.getCompiledChain @filename, { async: false }
-            scripts = []
-            for file in files
-                script = file.js
-                    .replace(/\\/g, '\\\\')
-                    .replace(/\n/g, '\\n')
-                    .replace(/\r/g, '')
-                    .replace(/'/g, '\\\'')
-                filename = pathutil.relative(pathutil.dirname(@filename), file.filename)
-                    .replace(/\\/g, '/')
-                scripts.push "// #{filename}\neval('#{script}\\n//@ sourceURL=#{filename}')\n"
-            @contents = scripts.join('\n')
-        else
-            @contents = snockets.getConcatenation @filename, { async: false, minify: @compress }
+        try
+            @filename = pathutil.resolve options.filename
+            @compress = options.compress or false
+            @debug = options.debug or false
+            snockets = new Snockets()
+            if @debug
+                files = snockets.getCompiledChain @filename, { async: false }
+                scripts = []
+                for file in files
+                    script = file.js
+                        .replace(/\\/g, '\\\\')
+                        .replace(/\n/g, '\\n')
+                        .replace(/\r/g, '')
+                        .replace(/'/g, '\\\'')
+                    filename = pathutil.relative(pathutil.dirname(@filename), file.filename)
+                        .replace(/\\/g, '\/')
+                    scripts.push "// #{filename}\neval('#{script}\\n//@ sourceURL=#{filename}')\n"
+                @contents = scripts.join('\n')
+            else
+                @contents = snockets.getConcatenation @filename, { async: false, minify: @compress }
+        catch e
+            @emit('error', e)
         @emit 'created'


### PR DESCRIPTION
Snockets was throwing uncaught errors when coffeescript compilation failed. This patch allows you to catch those exceptions through the "error" event. This patch also includes a fix for the error event (the previous compiled js ended up checking if 'error' == 1 which was always false).
