### PR TITLE
Don't require the coffee-script via absolute require - let npm/node find the right module

### DIFF
--- a/switch.js
+++ b/switch.js
@@ -2,6 +2,7 @@
 try {
     module.exports = require('./compiled');
 } catch(error) {
-    require('./node_modules/coffee-script');
+    //require('./node_modules/coffee-script');
+    require('coffee-script');
     module.exports = require('./lib');
 }


### PR DESCRIPTION
If i install the package via git, configured in the package.json and coffee-script is installed from the main application the switch.js require of coffee-script failed. This occures because coffee-script is installed in the node_modules directory of the application and not under the node_modules directory of the asset-rack module.

With the little changed it worked as expected.
