### PR TITLE
Fix watching angular templates

### DIFF
--- a/lib/modules/angular-templates.coffee
+++ b/lib/modules/angular-templates.coffee
@@ -9,6 +9,7 @@ class exports.AngularTemplatesAsset extends Asset
     create: (options) ->
         options.dirname ?= options.directory # for backwards compatiblity
         @dirname = pathutil.resolve options.dirname
+        @toWatch = @dirname
         @compress = options.compress or false
         files = fs.readdirSync @dirname
         templates = []


### PR DESCRIPTION
An error is thrown if you try to set the `watch` option to `true` when creating an `AngularTemplatesAsset` because `@toWatch` isn't set in `#create()`. This PR just makes it  watch `@dirname`.
