### PR TITLE
Updated browserify version

### DIFF
--- a/lib/modules/browserify.coffee
+++ b/lib/modules/browserify.coffee
@@ -21,7 +21,13 @@ class exports.BrowserifyAsset extends Asset
         for handler in @extensionHandlers
             agent.register(handler.ext, handler.handler)
         agent.add @filename
-        agent.require @require if @require
+
+        if @require
+            for r in @require
+                if r.file
+                    agent.require r.file, r.options
+                else
+                    agent.require r
 
         agent.external ext for ext in @external if @external
         agent.transform t for t in @transform if @transform

--- a/lib/modules/browserify.coffee
+++ b/lib/modules/browserify.coffee
@@ -13,17 +13,25 @@ class exports.BrowserifyAsset extends Asset
         @require = options.require
         @debug = options.debug or false
         @compress = options.compress
+        @external = options.external
+        @transform = options.transform
         @compress ?= false
         @extensionHandlers = options.extensionHandlers or []
         agent = browserify watch: false, debug: @debug
         for handler in @extensionHandlers
             agent.register(handler.ext, handler.handler)
-        agent.addEntry @filename
+        agent.require @filename
         agent.require @require if @require
-        if @compress is true
-            uncompressed = agent.bundle()
-            @contents = uglify.minify(uncompressed, {fromString: true}).code
-            @emit 'created'
-        else
-            @emit 'created', contents: agent.bundle()
 
+        agent.external ext for ext in @external if @external
+        agent.transform t for t in @transform if @transform
+
+        agent.transform 'coffeeify' if /.coffee$/.test @filename
+
+        agent.bundle (error, src) =>
+            # return @emit 'error', error if error?
+            if @compress is true
+                @contents = uglify.minify(src, {fromString: true}).code
+                @emit 'created'
+            else
+                @emit 'created', contents: src

--- a/lib/modules/browserify.coffee
+++ b/lib/modules/browserify.coffee
@@ -20,7 +20,7 @@ class exports.BrowserifyAsset extends Asset
         agent = browserify watch: false, debug: @debug
         for handler in @extensionHandlers
             agent.register(handler.ext, handler.handler)
-        agent.add @filename
+        agent.add @filename if @filename
 
         if @require
             for r in @require

--- a/lib/modules/browserify.coffee
+++ b/lib/modules/browserify.coffee
@@ -29,7 +29,7 @@ class exports.BrowserifyAsset extends Asset
         agent.transform 'coffeeify' if /.coffee$/.test @filename
 
         agent.bundle (error, src) =>
-            # return @emit 'error', error if error?
+            return @emit 'error', error if error?
             if @compress is true
                 @contents = uglify.minify(src, {fromString: true}).code
                 @emit 'created'

--- a/lib/modules/browserify.coffee
+++ b/lib/modules/browserify.coffee
@@ -20,7 +20,7 @@ class exports.BrowserifyAsset extends Asset
         agent = browserify watch: false, debug: @debug
         for handler in @extensionHandlers
             agent.register(handler.ext, handler.handler)
-        agent.require @filename
+        agent.add @filename
         agent.require @require if @require
 
         agent.external ext for ext in @external if @external

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Brad Carleton <brad@techpines.com>",
   "repository": "https://github.com/techpines/asset-rack",
   "dependencies": {
-    "browserify": "1.17.3",
+    "browserify": "~2.34.0",
     "snockets": "~1.3.8",
     "uglify-js": "~2.4.0",
     "async": "~0.2.9",
@@ -17,6 +17,7 @@
     "stylus": "~0.38.0",
     "underscore": "~1.5.2",
     "coffee-script": "~1.6.3",
+    "coffeeify": "~0.5.0",
     "markdown": "~0.5.0",
     "node-sassy": "~0.0.1"
   },


### PR DESCRIPTION
Updated to work with the latest version of Browserify.  Maintains backwards compatibility with coffee script by automatically using the coffeeify transform if the file ends in .coffee.

Also added support for defining transforms and externals on BrowserifyAsset.

Looks like Uglify was updated a few days ago, so if this gets pulled, #98 can be closed.
