### PR TITLE
Use gaze instead of fs.watch to implement file watching.

### DIFF
--- a/lib/asset.coffee
+++ b/lib/asset.coffee
@@ -107,13 +107,14 @@ class exports.Asset extends EventEmitter
         
             # Does the file watching
             if @watch
-                @watcher = fs.watch @toWatch, (event, filename) =>
-                    if event is 'change'
-                        @watcher.close()
-                        @completed = false
-                        @assets = false
-                        process.nextTick =>
-                            @emit 'start'
+                @watcher = new gaze.Gaze(@toWatch + "/*")
+                @watcher.on 'all', (event, filepath) =>
+                    @watcher.close()
+                    @completed = false
+                    @assets = false
+
+                    process.nextTick =>
+                        @emit 'start'
 
         # Listen for errors and throw if no listeners
         @on 'error', (error) =>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "underscore": "~1.5.2",
     "coffee-script": "~1.6.3",
     "markdown": "~0.5.0",
-    "node-sassy": "~0.0.1"
+    "node-sassy": "~0.0.1",
+    "gaze": "~0.4.3"
   },
   "devDependencies": {
     "express.io": "1.1.8",


### PR DESCRIPTION
Makes file watching more robust and fixes all issues for me. Addresses #87 and #41.

I was having issues with the old watch functionality. This fixes it for me.
