### PR TITLE
Angular templates asset

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -308,18 +308,72 @@ variable.
 
 ### AngularTemplatesAsset
 
-The angular templates asset packages all .html templates ready to be injected into the client side angularjs template cache.
+The angular templates asset packages all .html and .jade templates, in a given directory, ready to be injected into the client side angularjs template cache.
 You can read more about angularjs [here](http://angularjs.org/).
 
+#### Example:
+This example will compile html and jade documents located on the filesystem in the `__dirname + '../widget/app/views'` directory, and embed them in JS file served by the server at `'/js/widget/templates.js'`.
+
+_NOTE: all files in the `templateUrl` should use the `.html` file extension (including jade templates)_
+
+##### Server
+Project directory structure:
+```
+  MyExpressApp
+  ├── app.js
+  ├── assets.js
+  ├── public
+  │   └── js
+  │       └── (nothing on FS here)
+  └── widget
+      ├── app
+      │   ├── controllers
+      │   ├── directives
+      │   ├── services
+      │   └── views
+      │       ├── view1.html
+      │       └── view2.jade
+      └── test
+          ├── e2e
+          └── spec
+```
+In your project's `assets.js`:
 ```javascript
-new AngularTemplatesAsset({
-    url: '/js/templates.js',
-    dirname: __dirname + '/templates'
-});
+...
+  new rack.AngularTemplatesAsset({
+    url: '/js/widget/templates.js',
+    dirname: __dirname + '../widget/app/views',
+    templateCahceDirname: '/widget/views'
+  }),
+...
 ```
 
-Then see the following example client js code which loads templates into the template cache, where `angularTemplates` is the function provided by AngularTemplatesAsset:
+##### Client
+In angular route config:
+```javascript
+...
+  $routeProvider
+    .when('/view1/:id', {
+      templateUrl: '/widget/views/view1.html',
+      controller: 'MainCtrl'
+    },
+    .when('/view2/:id', {
+      templateUrl: '/widget/views/view2.html',
+      controller: 'MainCtrl'
+    },
+  )
+...
+```
 
+Then the following example client code loads templates into the template cache, where `angularTemplates` is the function provided by AngularTemplatesAsset:
+
+In your angular index.html:
+```html
+<script src='/js/widget/templates.js' type='text/javascript'></script>
+<script src='/path/to/angular/index-or-app.js' type='text/javascript'></script>
+```
+
+In your angular module initialization (usually index.js or app.js):
 ```javascript
 //replace this with your module initialization logic
 var myApp = angular.module("myApp", []);
@@ -331,8 +385,16 @@ myApp.run(['$templateCache', angularTemplates]);
 #### Options
 
 * `url`: The url that should retrieve this resource.
-* `dirname`: Directory where the .html templates are stored.
+* `dirname`: Directory where the .html and/or .jade templates are stored.
 * `compress` (defaults to false): Whether to unglify the js.
+* `templateCahceDirname` (defaults to empty string): Directory of the `templateUrl` you will be using in your angular routing configuration or directives to reference the template file.
+  * With `templateCacheDirname`: 
+    assets.js: `templateCahceDirname: '/widget/views'`
+    angular route config: `templateUrl: '/widget/views/view1.html',`
+  * Without:
+    angular route config: `templateUrl: '/view1.html',`
+    
+_NOTE: `templateCacheDirname` examples use the directory structure in the preceeding example_
 
 ## Other
 

--- a/lib/modules/angular-templates.coffee
+++ b/lib/modules/angular-templates.coffee
@@ -11,33 +11,47 @@ class exports.AngularTemplatesAsset extends Asset
     options.dirname ?= options.directory # for backwards compatiblity
     @dirname = pathutil.resolve options.dirname
     @toWatch = @dirname
+    @separator = options.separator or '/'
     @compress = options.compress or false
-    files = fs.readdirSync @dirname
-    templates = []
+    @root = options.root
 
-    for file in files
-      if file.match(/\.html$/)
-        template = fs.readFileSync(pathutil.join(@dirname, file), 'utf8').replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, '\\\'')
-        templates.push "$templateCache.put('#{file}', '#{template}')"
-      else if file.match(/\.jade$/)
-        template = fs.readFileSync(pathutil.join(this.dirname, file), 'utf8')
-        linker = jade.compile(template);
-        if @rack?
-          assets = {}
-          for asset in @rack.assets
-            assets[asset.url] = asset.specificUrl
-
-          @assetsMap = {
-            assets:
-              assets: assets,
-              url: (url)-> @assets[url]
-          }
-        compiledTemplate = linker(@assetsMap if @assetsMap).replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, '\\\'')
-        templates.push("$templateCache.put('" + file.replace(/\.jade/, '.html') + "', '" + compiledTemplate + "')")
-
+    templates = @getFileObjects(@dirname)
     javascript = "var angularTemplates = function($templateCache) {\n#{templates.join('\n')}}"
     if options.compress is true
       @contents = uglify.minify(javascript, { fromString: true }).code
     else
       @contents = javascript
     @emit 'created'
+
+
+
+  getFileObjects: (dirname, prefix='') ->
+    files = fs.readdirSync dirname
+    templates = []
+    for file in files
+      continue if file.slice(0, 1) is '.'
+      path = pathutil.join dirname, file
+      stats = fs.statSync path
+      if stats.isDirectory()
+          newPrefix = "#{prefix}#{pathutil.basename(path)}#{@separator}"
+          templates = templates.concat @getFileObjects path, newPrefix
+      else
+        if file.match(/\.html$/)
+          template = fs.readFileSync(path, 'utf8').replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, '\\\'')
+          templates.push "$templateCache.put('#{path}', '#{template}')"
+        else if file.match(/\.jade$/)
+          template = fs.readFileSync(path, 'utf8')
+          linker = jade.compile(template, {filename: path});
+          if @rack?
+            assets = {}
+            for asset in @rack.assets
+              assets[asset.url] = asset.specificUrl
+
+            @assetsMap = {
+              assets:
+                assets: assets,
+                url: (url)-> @assets[url]
+            }
+          compiledTemplate = linker(@assetsMap if @assetsMap).replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, '\\\'')
+          templates.push("$templateCache.put('" + pathutil.join(@root, file).replace(/\.jade/, '.html') + "', '" + compiledTemplate + "')")
+    templates

--- a/lib/modules/angular-templates.coffee
+++ b/lib/modules/angular-templates.coffee
@@ -13,7 +13,7 @@ class exports.AngularTemplatesAsset extends Asset
     @toWatch = @dirname
     @separator = options.separator or '/'
     @compress = options.compress or false
-    @root = options.root
+    @templateCacheDirname = options.templateCacheDirname
 
     templates = @getFileObjects(@dirname)
     javascript = "var angularTemplates = function($templateCache) {\n#{templates.join('\n')}}"
@@ -33,12 +33,13 @@ class exports.AngularTemplatesAsset extends Asset
       path = pathutil.join dirname, file
       stats = fs.statSync path
       if stats.isDirectory()
-          newPrefix = "#{prefix}#{pathutil.basename(path)}#{@separator}"
-          templates = templates.concat @getFileObjects path, newPrefix
+        newPrefix = "#{prefix}#{pathutil.basename(path)}#{@separator}"
+        templates = templates.concat @getFileObjects path, newPrefix
       else
         if file.match(/\.html$/)
           template = fs.readFileSync(path, 'utf8').replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, '\\\'')
-          templates.push "$templateCache.put('#{path}', '#{template}')"
+          templateCacheDirname = (if @templateCacheDirname then pathutil.join(@templateCacheDirname, file) else "/#{file}").replace(/\.jade/, '.html')
+          templates.push "$templateCache.put('#{templateCacheDirname}', '#{template}')"
         else if file.match(/\.jade$/)
           template = fs.readFileSync(path, 'utf8')
           linker = jade.compile(template, {filename: path});
@@ -52,6 +53,8 @@ class exports.AngularTemplatesAsset extends Asset
                 assets: assets,
                 url: (url)-> @assets[url]
             }
+
+          templateCacheDirname = (if @templateCacheDirname then pathutil.join(@templateCacheDirname, file) else "/#{file}").replace(/\.jade/, '.html')
           compiledTemplate = linker(@assetsMap if @assetsMap).replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, '\\\'')
-          templates.push("$templateCache.put('" + pathutil.join(@root, file).replace(/\.jade/, '.html') + "', '" + compiledTemplate + "')")
+          templates.push("$templateCache.put('#{templateCacheDirname}', '#{compiledTemplate}')")
     templates

--- a/lib/modules/angular-templates.coffee
+++ b/lib/modules/angular-templates.coffee
@@ -2,25 +2,42 @@ fs = require 'fs'
 pathutil = require 'path'
 uglify = require 'uglify-js'
 Asset = require('../index').Asset
+jade = require('jade')
 
 class exports.AngularTemplatesAsset extends Asset
-    mimetype: 'text/javascript'
+  mimetype: 'text/javascript'
 
-    create: (options) ->
-        options.dirname ?= options.directory # for backwards compatiblity
-        @dirname = pathutil.resolve options.dirname
-        @toWatch = @dirname
-        @compress = options.compress or false
-        files = fs.readdirSync @dirname
-        templates = []
+  create: (options) ->
+    options.dirname ?= options.directory # for backwards compatiblity
+    @dirname = pathutil.resolve options.dirname
+    @toWatch = @dirname
+    @compress = options.compress or false
+    files = fs.readdirSync @dirname
+    templates = []
 
-        for file in files when file.match(/\.html$/)
-            template = fs.readFileSync(pathutil.join(@dirname, file), 'utf8').replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, '\\\'')
-            templates.push "$templateCache.put('#{file}', '#{template}')"
+    for file in files
+      if file.match(/\.html$/)
+        template = fs.readFileSync(pathutil.join(@dirname, file), 'utf8').replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, '\\\'')
+        templates.push "$templateCache.put('#{file}', '#{template}')"
+      else if file.match(/\.jade$/)
+        template = fs.readFileSync(pathutil.join(this.dirname, file), 'utf8')
+        linker = jade.compile(template);
+        if @rack?
+          assets = {}
+          for asset in @rack.assets
+            assets[asset.url] = asset.specificUrl
 
-        javascript = "var angularTemplates = function($templateCache) {\n#{templates.join('\n')}}"
-        if options.compress is true
-            @contents = uglify.minify(javascript, { fromString: true }).code
-        else
-            @contents = javascript
-        @emit 'created'
+          @assetsMap = {
+            assets:
+              assets: assets,
+              url: (url)-> @assets[url]
+          }
+        compiledTemplate = linker(@assetsMap if @assetsMap).replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, '\\\'')
+        templates.push("$templateCache.put('" + file.replace(/\.jade/, '.html') + "', '" + compiledTemplate + "')")
+
+    javascript = "var angularTemplates = function($templateCache) {\n#{templates.join('\n')}}"
+    if options.compress is true
+      @contents = uglify.minify(javascript, { fromString: true }).code
+    else
+      @contents = javascript
+    @emit 'created'


### PR DESCRIPTION
### Synopsis:

This will allow the directory in which your angular templates live to contain jade and/or html and will compile (in the case of jade) and put them in the $templateCache.

This does work with the `@rack.assets` object if you have multiple assets and are using `assets.url(...)` in your jade templates.

Need to add the example to the readme but the only notable bit is the need for a `templateCacheDirname` option **for each AngularTemplatesAsset asset**. The value of the `templateCacheDirname` option is the dirname of the `templateUrl` you will be using in your angular routing configuration or directives to reference the template file.
### Example:

This example will compile html and jade documents located on the filesystem in the `__dirname + '../widget/app/views'` directory, and embed them in JS file served by the server at `'/js/widget/templates.js'`.

_NOTE: all files in the `templateUrl` should use the `.html` file extension (including jade templates)_
#### Server

Project directory structure:

```
  MyExpressApp
  ├── app.js
  ├── assets.js
  ├── public
  │   └── js
  │       └── (nothing on FS here)
  └── widget
      ├── app
      │   ├── controllers
      │   ├── directives
      │   ├── services
      │   └── views
      │       ├── view1.html
      │       └── view2.jade
      └── test
          ├── e2e
          └── spec
```

In your projects `assets.js`:

```
...
  new rack.AngularTemplatesAsset({
    url: '/js/widget/templates.js',
    dirname: __dirname + '../widget/app/views',
    templateCacheDirname: '/widget/views'
  }),
...
```
#### Client

In an angular route config:

```
...
  $routeProvider
    .when('/view1/:id', {
      templateUrl: '/widget/views/view1.html',
      controller: 'MainCtrl'
    },
    .when('/view2/:id', {
      templateUrl: '/widget/views/view2.html',
      controller: 'MainCtrl'
    },
  )
...
```
