### PR TITLE
Add `prepend` option to BrowserifyAsset and update readme

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -185,7 +185,7 @@ as the `filename` argument should pull in any requires you need.
 * `prepend` (optional): prepend another javascript asset (e.g. AngularTemplatesAsset or JadeAsset) to the browserify bundled javascript.
 
 
-##### Prepend Example - Angular:
+##### Prepend Example:
 _(using `rack.Rack([])` - multiple assets syntax)_
 
 In your assets.js:
@@ -201,6 +201,37 @@ var assets = rack.Rack([
     url: '/app.js',
     filename: __dirname + '/myAnglarApp/app.js',
     prepend: angularTemplatesAsset
+  });
+]);
+
+module.exports = assets;
+```
+
+In your client (angular in this case) index.html:
+```html
+<script src='/app.js' type='text/javascript'></script>
+```
+
+##### Prepend Example - prepend multiple assets:
+_(using `rack.Rack([])` - multiple assets syntax)_
+
+In your assets.js:
+```javascript
+var rack = require('asset-rack');
+var widgetTemplates = new rack.AngularTemplatesAsset({
+  url: '/widget/templates.js',
+  dirname: __dirname + '/relative/path/to/widget/templates'
+});
+var sharedTemplates = new rack.AngularTemplatesAsset({
+  url: '/shared/templates.js',
+  dirname: __dirname + '/relative/path/to/shared/templates'
+});
+
+var assets = rack.Rack([
+  new rack.BrowserifyAsset({
+    url: '/app.js',
+    filename: __dirname + '/myAnglarApp/app.js',
+    prepend: [widgetTemplates, sharedTemplates]
   });
 ]);
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -182,6 +182,37 @@ as the `filename` argument should pull in any requires you need.
 * `debug` (defaults to false): enables the browserify debug option.
 * `compress` (defaults to false): whether to run the javascript through a minifier.
 * `extensionHandlers` (defaults to []): an array of custom extensions and associated handler function. eg: `[{ ext: 'handlebars', handler: handlebarsCompilerFunction }]`
+* `prepend` (optional): prepend another javascript asset (e.g. AngularTemplatesAsset or JadeAsset) to the browserify bundled javascript.
+
+
+##### Prepend Example - Angular:
+_(using `rack.Rack([])` - multiple assets syntax)_
+
+In your assets.js:
+```javascript
+var rack = require('asset-rack');
+var angularTemplatesAsset = new rack.AngularTemplatesAsset({
+  url: '/templates.js',
+  dirname: __dirname + '/relative/path/to/templates'
+});
+
+var assets = rack.Rack([
+  new rack.BrowserifyAsset({
+    url: '/app.js',
+    filename: __dirname + '/myAnglarApp/app.js',
+    prepend: angularTemplatesAsset
+  });
+]);
+
+module.exports = assets;
+```
+
+In your client (angular in this case) index.html:
+```html
+<script src='/app.js' type='text/javascript'></script>
+```
+
+_Reference [AngularTemplatesAsset](#angulartemplatesasset) or [JadeAsset](#jadeasset) for more details specific to either._
 
 ### SnocketsAsset (js/coffeescript)
 

--- a/lib/modules/browserify.coffee
+++ b/lib/modules/browserify.coffee
@@ -8,22 +8,35 @@ class exports.BrowserifyAsset extends Asset
     mimetype: 'text/javascript'
 
     create: (options) ->
-        @filename = options.filename
-        @toWatch = pathutil.dirname pathutil.resolve @filename
-        @require = options.require
-        @debug = options.debug or false
-        @compress = options.compress
-        @compress ?= false
-        @extensionHandlers = options.extensionHandlers or []
-        agent = browserify watch: false, debug: @debug
-        for handler in @extensionHandlers
-            agent.register(handler.ext, handler.handler)
-        agent.addEntry @filename
-        agent.require @require if @require
-        if @compress is true
+      @filename = options.filename
+      @toWatch = pathutil.dirname pathutil.resolve @filename
+      @require = options.require
+      @debug = options.debug or false
+      @compress = options.compress
+      @prependAsset = options.prepend
+      @compress ?= false
+      @extensionHandlers = options.extensionHandlers or []
+      agent = browserify watch: false, debug: @debug
+      for handler in @extensionHandlers
+          agent.register(handler.ext, handler.handler)
+      agent.addEntry @filename
+      agent.require @require if @require
+      
+      self = @
+      if @prependAsset
+        @prependAsset.on 'complete', ()->
+          self.contents = @contents + '\n;\n'
+          if self.compress is true
             uncompressed = agent.bundle()
-            @contents = uglify.minify(uncompressed, {fromString: true}).code
-            @emit 'created'
-        else
-            @emit 'created', contents: agent.bundle()
+            self.contents += uglify.minify(uncompressed, {fromString: true}).code
+            self.emit 'created'
+          else
+            self.emit 'created', contents: self.contents += agent.bundle()
+      else
+        if @compress is true
+              uncompressed = agent.bundle()
+              @contents = uglify.minify(uncompressed, {fromString: true}).code
+              @emit 'created'
+          else
+              @emit 'created', contents: agent.bundle()
 

--- a/lib/modules/browserify.coffee
+++ b/lib/modules/browserify.coffee
@@ -33,7 +33,7 @@ class exports.BrowserifyAsset extends Asset
           deferred = Q.defer()
           promises.push deferred.promise
           asset.on 'complete', ()->
-            deferred.resolve @contents
+            deferred.resolve asset.contents
         Q.all(promises).done (contentsArray)->
           @finish(contentsArray.join(delimiter) + delimiter)
       else

--- a/lib/modules/browserify.coffee
+++ b/lib/modules/browserify.coffee
@@ -23,18 +23,17 @@ class exports.BrowserifyAsset extends Asset
       @agent.addEntry @filename
       @agent.require @require if @require
       delimiter = '\n;\n'
-      
-      self = @
+
       if @prependAsset
         promises = []
         unless @prependAsset instanceof Array
           @prependAsset = [@prependAsset]
-        for asset in @prependAsset
+        @prependAsset.forEach (asset)=>
           deferred = Q.defer()
           promises.push deferred.promise
           asset.on 'complete', ()->
             deferred.resolve asset.contents
-        Q.all(promises).done (contentsArray)->
+        Q.all(promises).done (contentsArray)=>
           @finish(contentsArray.join(delimiter) + delimiter)
       else
         @finish('')

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "underscore": "~1.5.2",
     "coffee-script": "~1.6.3",
     "markdown": "~0.5.0",
-    "node-sassy": "~0.0.1"
+    "node-sassy": "~0.0.1",
+    "q": "~0.9.7"
   },
   "devDependencies": {
     "express.io": "1.1.8",


### PR DESCRIPTION
### Synopsis:

Adds an optional `prepend` option to `BrowserifyAsset`. This will allow the Browserify asset to include another javascript asset at the beginning of the file it generates. 
### Use Case:

A specific use case is discussed in issue #82 and in conjunction with PR #107 should allow for a single asset to serve a bundle of all of a client apps JS files **and** it's templates via a single script tag.
### Example:

_The example project described below can be found [here](https://github.com/bryanchriswhite/AssetRackExample)_

Project directory structure:

```
AssetRackExample
├── app.js
├── assets.js
├── public
│   ├── index.html
└── widget
    ├── app
    │   ├── controllers
    │   │   └── index.js
    │   ├── directives
    │   ├── index.js
    │   └── views
    │       ├── view1.html
    │       └── view2.html
    └── test
        ├── e2e
        └── spec
```
#### Server

In assets.js (/assets.js):

``` javascript
var rack = require('asset-rack')
  , assets = new rack.Rack([
    new rack.BrowserifyAsset({
      url     : '/js/widget.bundle.js',
      filename: __dirname + '/widget/app/index.js',
      prepend : new rack.AngularTemplatesAsset({
        url    : '/js/widget/templates.js',
        dirname: __dirname + '/widget/app/views'
      })
    })
  ])
  ;

module.exports = assets;
```

In app.js (/app.js):

``` javascript
var assets = require('./assets');
app.use(assets);
```
#### Client

In index.html (public/index.html):

``` html
<script src='/js/widget.bundle.js' type="text/javascript"></script>
```

In index.js (widget/app/index.js):

``` javascript
angular.module('myApp', [])
  .config([
    '$routeProvider', function($routeProvider) {
      $routeProvider
        .when('/one', {
          templateUrl: 'view1.html',
          controller : 'MainCtrl'
        })
        .when('/two', {
          templateUrl: 'view2.html',
          controller : 'MainCtrl'
        })
    }
  ])
  .run(['$templateCache', angularTemplates]);
require('./controllers');
```

Should wrap up issue #82
