### PR TITLE
add `clientVariable` option to `AngularTemplatesAsset` and update readme

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -333,6 +333,7 @@ myApp.run(['$templateCache', angularTemplates]);
 * `url`: The url that should retrieve this resource.
 * `dirname`: Directory where the .html templates are stored.
 * `compress` (defaults to false): Whether to unglify the js.
+* `clientVariable` (defualts to 'angularTemplates'): Client side template variable.
 
 ## Other
 

--- a/lib/modules/angular-templates.coffee
+++ b/lib/modules/angular-templates.coffee
@@ -11,6 +11,7 @@ class exports.AngularTemplatesAsset extends Asset
         @dirname = pathutil.resolve options.dirname
         @toWatch = @dirname
         @compress = options.compress or false
+        @clientVariable = options.clientVariable or 'angularTemplates'
         files = fs.readdirSync @dirname
         templates = []
 
@@ -18,7 +19,7 @@ class exports.AngularTemplatesAsset extends Asset
             template = fs.readFileSync(pathutil.join(@dirname, file), 'utf8').replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, '\\\'')
             templates.push "$templateCache.put('#{file}', '#{template}')"
 
-        javascript = "var angularTemplates = function($templateCache) {\n#{templates.join('\n')}}"
+        javascript = "var #{@clientVariable} = function($templateCache) {\n#{templates.join('\n')}}"
         if options.compress is true
             @contents = uglify.minify(javascript, { fromString: true }).code
         else


### PR DESCRIPTION
This change is necessary in order to use the `BrowserifyAsset`'s purposed `prepend` option (as per PR #109) with multiple `AngularTemplatesAssets`. Prior to this they always used the `angularTemplates` client side global variable which means that if you "prepend" 2 or more, they overwrite each other and the last one wins.

It can be used stand-alone as well though, which is why I've created a separate PR.
