### PR TITLE
allowing for \r\n line endings in angular-templates

### DIFF
--- a/lib/modules/angular-templates.coffee
+++ b/lib/modules/angular-templates.coffee
@@ -15,7 +15,7 @@ class exports.AngularTemplatesAsset extends Asset
         templates = []
 
         for file in files when file.match(/\.html$/)
-            template = fs.readFileSync(pathutil.join(@dirname, file), 'utf8').replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/'/g, '\\\'')
+            template = fs.readFileSync(pathutil.join(@dirname, file), 'utf8').replace(/\\/g, '\\\\').replace(/\r?\n/g, '\\n').replace(/'/g, '\\\'')
             templates.push "$templateCache.put('#{file}', '#{template}')"
 
         javascript = "var angularTemplates = function($templateCache) {\n#{templates.join('\n')}}"


### PR DESCRIPTION
A small change to a regex in angular-templates so that it can cope with templates files that have \r\n line endings. Otherwise the \r characters get left in and it outputs invalid javascript.
