### PR TITLE
Add Gaze and subdirectory watching support

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -34,7 +34,7 @@ app.use(asset);
 * `headers`: Any specific headers you want associated with this asset.
 * `mimetype`: The content type for the asset.
 * `hash`: (defaults to undefined) Serves both hashed and unhashed urls.  If set to `true` then it only serves the hashed version, and if false then it only serves the unhashed version.
-* `watch`: (defaults to false) Watches for file changes and recreates assets.
+* `watch`: (defaults to false) Watches for file changes and recreates assets. If set to `recursive` it will watch all subdirectories of this asset for changes as well.
 * `gzip`: (defaults to false) Whether to gzip the contents
 * `allowNoHashCache`: By default unhashed urls will not be cached.  To allow them to be hashed, set this option to `true`.
 * `maxAge`: How long to cache the resource, defaults to 1 year for hashed urls, and no cache for unhashed urls.

--- a/lib/asset.coffee
+++ b/lib/asset.coffee
@@ -5,7 +5,7 @@
 async = require 'async'
 crypto = require 'crypto'
 pathutil = require 'path'
-fs = require 'fs'
+gaze = require 'gaze'
 zlib = require 'zlib'
 mime = require 'mime'
 {extend} = require './util'
@@ -107,13 +107,18 @@ class exports.Asset extends EventEmitter
         
             # Does the file watching
             if @watch
-                @watcher = fs.watch @toWatch, (event, filename) =>
-                    if event is 'change'
-                        @watcher.close()
-                        @completed = false
-                        @assets = false
-                        process.nextTick =>
-                            @emit 'start'
+                if @watch == 'recursive'
+                  watchPath = pathutil.join(@toWatch, '**', '*')
+                else
+                  watchPath = pathutil.join(@toWatch, '*')
+
+                @watcher = new gaze.Gaze(watchPath)
+                @watcher.on 'all', (event, filepath) =>
+                    @watcher.close()
+                    @completed = false
+                    @assets = false
+                    process.nextTick =>
+                        @emit 'start'
 
         # Listen for errors and throw if no listeners
         @on 'error', (error) =>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "underscore": "~1.5.2",
     "coffee-script": "~1.6.3",
     "markdown": "~0.5.0",
-    "node-sassy": "~0.0.1"
+    "node-sassy": "~0.0.1",
+    "gaze": "~0.5.0"
   },
   "devDependencies": {
     "express.io": "1.1.8",


### PR DESCRIPTION
This adds [Gaze](https://github.com/shama/gaze) for better file watching support.  

This also extends the `watch` option to allow for recursive directory watching.  This is useful when we have one main asset which includes others, which may be located in a subdirectory. For example, having an a SnocketsAsset `application.js` require `./helpers/something.js`.

This is similar to #105, but that issue looks abandoned.
