### PR TITLE
Express 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ asset = new rack.Asset({
 Need to serve that asset with a blisteringly fast in memory cache using express?
 
 ```
-app.use(asset)
+app.use(asset.handle)
 ```
 
 ### Hash for speed and efficiency
@@ -205,7 +205,7 @@ assets = rack.fromConfigFile({
     configFile: __dirname + '/rack.json',
     hostname: 'cdn.example.com'
 });
-app.use(assets);
+app.use(assets.handle);
 ```
 
 And now all of your server side templates will reference your CDN.  Also, if you do happen to hit one of your static urls on the server, then you will be redirected to the CDN.

--- a/lib/asset.coffee
+++ b/lib/asset.coffee
@@ -159,7 +159,7 @@ class exports.Asset extends EventEmitter
         url is @specificUrl or (not @hash? and url is @url)
 
     # Used so that an asset can be express middleware
-    handle: (request, response, next) ->
+    handle: (request, response, next) =>
         handle = =>
             if @assets?
                 for asset in @assets

--- a/lib/rack.coffee
+++ b/lib/rack.coffee
@@ -76,10 +76,10 @@ class exports.Rack extends EventEmitter
         , (error) =>
             return @emit 'error', error if error?
             @emit 'complete'
-        
+
     # Makes the rack function as express middleware
-    handle: (request, response, next) ->
-        response.locals assets: this
+    handle: (request, response, next) =>
+        response.app.locals.assets = this
         if request.url.slice(0,11) is '/asset-rack'
             return @handleAdmin request, response, next
         if @hasError
@@ -199,10 +199,10 @@ class ConfigRack
         # Setup our options
         @assetMap = require options.configFile
         @hostname = options.hostname
-        
+
     # For hooking up as express middleware
-    handle: (request, response, next) ->
-        response.locals assets: this
+    handle: (request, response, next) =>
+        response.app.locals assets: this
         for url, specificUrl of @assetMap
             if request.path is url or request.path is specificUrl
 

--- a/lib/rack.coffee
+++ b/lib/rack.coffee
@@ -202,7 +202,7 @@ class ConfigRack
 
     # For hooking up as express middleware
     handle: (request, response, next) =>
-        response.app.locals assets: this
+        response.app.locals.assets = this
         for url, specificUrl of @assetMap
             if request.path is url or request.path is specificUrl
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "nib": "~1.0.1",
     "stylus": "~0.38.0",
     "underscore": "~1.5.2",
-    "coffee-script": "~1.6.3",
+    "coffee-script": "~1.7.1",
     "markdown": "~0.5.0",
     "node-sassy": "~0.0.1"
   },
@@ -27,7 +27,7 @@
     "chai": "1.4.2"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha test/test.coffee",
+    "test": "./node_modules/mocha/bin/mocha --compilers coffee:coffee-script/register test/test.coffee",
     "compile": "./node_modules/coffee-script/bin/coffee -o compiled/ -c lib/",
     "prepublish": "echo $(pwd) > /tmp/.pwd; ./node_modules/coffee-script/bin/coffee -o compiled/ -c lib/;",
     "postpublish": "rm -rf $(cat /tmp/.pwd)/compiled"

--- a/switch.js
+++ b/switch.js
@@ -3,6 +3,7 @@ try {
     module.exports = require('./compiled');
 } catch(error) {
     //require('./node_modules/coffee-script');
-    require('coffee-script');
+    var CoffeeScript = require('coffee-script');
+    CoffeeScript.register();
     module.exports = require('./lib');
 }


### PR DESCRIPTION
Now that Express 4 no longer excepts objects as middleware we have to use callbacks instead.

To keep asset-rack working in express 4, with some kind of fallback capabilities for express 3, I'm proposing to specify the `Rack#handle` method when adding the rack/asset as middleware. I've also upgraded CoffeeScript, so I could easily bind the class's method to any instance
of it with the new fat-arrow syntax.

Another problem is the `express.Response#locals` property is no longer a function. Therefore I've added the assets' "locals" property directly to
the express instance.
