### PR TITLE
Pass gzip option through to assets

### DIFF
--- a/lib/modules/dynamic.coffee
+++ b/lib/modules/dynamic.coffee
@@ -18,6 +18,7 @@ class exports.DynamicAssets extends Asset
         @options ?= {}
         @options.hash = @hash
         @options.maxAge = @maxAge
+        @options.gzip = options.gzip
 
         @assets = []
         walk @dirname,


### PR DESCRIPTION
It would be nice if you could set `gzip: true` on all assets in a directory.

```
var assets = new rack.Rack([
  new rack.StaticAssets({
    urlPrefix: '/assets'
  , dirname: __dirname + '/assets'
  , gzip: true
  })
]);
```
